### PR TITLE
Add configuration for SSF-Elections CSV files

### DIFF
--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e01.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e01.json
@@ -1,0 +1,272 @@
+{
+  "SchemeID": "Scheme-4bdcb6a1",
+  "Name": "RQA S01E01",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-0856857a",
+      "CodeType": "Normal",
+      "DisplayText": "free and fairness",
+      "NumericValue": 1,
+      "StringValue": "free_and_fairness",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6ca035b0",
+      "CodeType": "Normal",
+      "DisplayText": "security and stability",
+      "NumericValue": 2,
+      "StringValue": "security_and_stability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-feda25d0",
+      "CodeType": "Normal",
+      "DisplayText": "better governance",
+      "NumericValue": 3,
+      "StringValue": "better_governance",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3b36a2ee",
+      "CodeType": "Normal",
+      "DisplayText": "unity and cohesion",
+      "NumericValue": 4,
+      "StringValue": "unity_and_cohesion",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-9db1ba52",
+      "CodeType": "Normal",
+      "DisplayText": "eradiacte clannism",
+      "NumericValue": 5,
+      "StringValue": "eradiacte_clannism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-fca5acbd",
+      "CodeType": "Normal",
+      "DisplayText": "development and prosperity",
+      "NumericValue": 6,
+      "StringValue": "development_and_prosperity",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f7e42127",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 7,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e02.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e02.json
@@ -1,0 +1,272 @@
+{
+  "SchemeID": "Scheme-4af609ab",
+  "Name": "RQA S01E02",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-8cdc7423",
+      "CodeType": "Normal",
+      "DisplayText": "building trust",
+      "NumericValue": 1,
+      "StringValue": "building_trust",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d288b4bc",
+      "CodeType": "Normal",
+      "DisplayText": "awareness creation",
+      "NumericValue": 2,
+      "StringValue": "awareness_creation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f9fa5d85",
+      "CodeType": "Normal",
+      "DisplayText": "fairness",
+      "NumericValue": 3,
+      "StringValue": "fairness",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-aa9a1fde",
+      "CodeType": "Normal",
+      "DisplayText": "peace and security",
+      "NumericValue": 4,
+      "StringValue": "peace_and_security",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d7ff8983",
+      "CodeType": "Normal",
+      "DisplayText": "abolish 4.5 system",
+      "NumericValue": 5,
+      "StringValue": "abolish_4_5_system",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a06185b9",
+      "CodeType": "Normal",
+      "DisplayText": "unity & cooperation",
+      "NumericValue": 6,
+      "StringValue": "unity_and_cooperation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-0b95daac",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 7,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e03.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e03.json
@@ -1,0 +1,272 @@
+{
+  "SchemeID": "Scheme-cc229f6e",
+  "Name": "RQA S01E03",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-dc91cbb9",
+      "CodeType": "Normal",
+      "DisplayText": "cooperate with security agents",
+      "NumericValue": 1,
+      "StringValue": "cooperate_with_security_agents",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a9fdf96f",
+      "CodeType": "Normal",
+      "DisplayText": "unity and cohesion",
+      "NumericValue": 2,
+      "StringValue": "unity_and_cohesion",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-06013f8f",
+      "CodeType": "Normal",
+      "DisplayText": "create awareness",
+      "NumericValue": 3,
+      "StringValue": "create_awareness",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a72be4c6",
+      "CodeType": "Normal",
+      "DisplayText": "involve them in the election process",
+      "NumericValue": 4,
+      "StringValue": "involve_them_in_the_election_process",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-055daff0",
+      "CodeType": "Normal",
+      "DisplayText": "job creation",
+      "NumericValue": 5,
+      "StringValue": "job_creation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-dd35e841",
+      "CodeType": "Normal",
+      "DisplayText": "stop clannism",
+      "NumericValue": 6,
+      "StringValue": "stop_clannism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a6f73d2d",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 7,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e04.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e04.json
@@ -1,0 +1,280 @@
+{
+  "SchemeID": "Scheme-3ee59aef",
+  "Name": "RQA S01E04",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-75d529d7",
+      "CodeType": "Normal",
+      "DisplayText": "justice and equality",
+      "NumericValue": 1,
+      "StringValue": "justice_and_equality",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-9db51725",
+      "CodeType": "Normal",
+      "DisplayText": "peace and security",
+      "NumericValue": 2,
+      "StringValue": "peace_and_security",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-1dc42dae",
+      "CodeType": "Normal",
+      "DisplayText": "religion",
+      "NumericValue": 3,
+      "StringValue": "religion",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3445f13f",
+      "CodeType": "Normal",
+      "DisplayText": "eliminating clannism",
+      "NumericValue": 4,
+      "StringValue": "eliminating_clannism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6e8064ab",
+      "CodeType": "Normal",
+      "DisplayText": "cooperation and cohesion",
+      "NumericValue": 5,
+      "StringValue": "cooperation_and_cohesion",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-1d24502a",
+      "CodeType": "Normal",
+      "DisplayText": "building trust",
+      "NumericValue": 6,
+      "StringValue": "building_trust",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b15fa927",
+      "CodeType": "Normal",
+      "DisplayText": "avoiding corruption",
+      "NumericValue": 7,
+      "StringValue": "avoiding_corruption",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-421bc6d4",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 8,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e05.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e05.json
@@ -1,0 +1,272 @@
+{
+  "SchemeID": "Scheme-bd776a46",
+  "Name": "RQA S01E05",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-ed57d5a8",
+      "CodeType": "Normal",
+      "DisplayText": "ensure peace and security",
+      "NumericValue": 1,
+      "StringValue": "ensure_peace_and_security",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-e6515464",
+      "CodeType": "Normal",
+      "DisplayText": "free and fair elections",
+      "NumericValue": 2,
+      "StringValue": "free_and_fair_elections",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-c4e64a75",
+      "CodeType": "Normal",
+      "DisplayText": "unity and cooperation",
+      "NumericValue": 3,
+      "StringValue": "unity_and_cooperation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-898f804f",
+      "CodeType": "Normal",
+      "DisplayText": "stop clannism",
+      "NumericValue": 4,
+      "StringValue": "stop_clannism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f57696e1",
+      "CodeType": "Normal",
+      "DisplayText": "avoiding corruption",
+      "NumericValue": 5,
+      "StringValue": "avoiding_corruption",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d7951003",
+      "CodeType": "Normal",
+      "DisplayText": "better achievement",
+      "NumericValue": 6,
+      "StringValue": "better_achievement",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-eddbf1ee",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 7,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e06.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e06.json
@@ -1,0 +1,272 @@
+{
+  "SchemeID": "Scheme-e5fb94bb",
+  "Name": "RQA S01E06",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-a7576453",
+      "CodeType": "Normal",
+      "DisplayText": "unity and cooperation",
+      "NumericValue": 1,
+      "StringValue": "unity_and_cooperation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-43c82dfd",
+      "CodeType": "Normal",
+      "DisplayText": "justice and equality",
+      "NumericValue": 2,
+      "StringValue": "justice_and_equality",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-910ca086",
+      "CodeType": "Normal",
+      "DisplayText": "awareness creation",
+      "NumericValue": 3,
+      "StringValue": "awareness_creation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f1a248f2",
+      "CodeType": "Normal",
+      "DisplayText": "inclusion in peace initiatives",
+      "NumericValue": 4,
+      "StringValue": "inclusion_in_peace_initiatives",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-cc30eef7",
+      "CodeType": "Normal",
+      "DisplayText": "abstaining clannism and discrimination",
+      "NumericValue": 5,
+      "StringValue": "abstaining_clannism_and_discrimination",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-0fad6b12",
+      "CodeType": "Normal",
+      "DisplayText": "reconciliation and dialogue",
+      "NumericValue": 6,
+      "StringValue": "reconciliation_and_dialogue",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-19c5cd72",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 7,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e07.json
+++ b/code_schemes/previous_rqas/ssf_elections/ssf_elections_rqa_s01e07.json
@@ -1,0 +1,256 @@
+{
+  "SchemeID": "Scheme-073059f5",
+  "Name": "RQA S01E07",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-0758f4fd",
+      "CodeType": "Normal",
+      "DisplayText": "provide encouragement",
+      "NumericValue": 1,
+      "StringValue": "provide_encouragement",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-97deb286",
+      "CodeType": "Normal",
+      "DisplayText": "has had influence",
+      "NumericValue": 2,
+      "StringValue": "has_had_influence",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-82c9d907",
+      "CodeType": "Normal",
+      "DisplayText": "awareness creation",
+      "NumericValue": 3,
+      "StringValue": "awareness_creation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-2d502b57",
+      "CodeType": "Normal",
+      "DisplayText": "no influence",
+      "NumericValue": 4,
+      "StringValue": "no_influence",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-85ece0fb",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 5,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": true,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": true,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": true
+      },
+      {
+        "NumericValue": -100140,
+        "CodeID": "code-I-b13a41f6",
+        "CodeType": "Meta",
+        "MetaCode": "impact",
+        "StringValue": "impact",
+        "DisplayText": "meta: impact",
+        "VisibleInCoda": true
+      }
+  ]
+}

--- a/docker-sync-csvs-to-engagement-db.sh
+++ b/docker-sync-csvs-to-engagement-db.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+PROJECT_NAME="$(<configurations/docker_image_project_name.txt)"
+IMAGE_NAME=$PROJECT_NAME-sync-csvs-to-engagement-db
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN="--dry-run"
+            shift;;
+        --incremental-cache-volume)
+            INCREMENTAL_ARG="--incremental-cache-path /cache"
+            INCREMENTAL_CACHE_VOLUME_NAME="$2"
+            shift 2;;
+        --)
+            shift
+            break;;
+        *)
+            break;;
+    esac
+done
+
+# Check that the correct number of arguments were provided.
+if [[ $# -ne 4 ]]; then
+    echo "Usage: $0 
+    [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
+    <user> <google-cloud-credentials-file-path> <configuration-module> <data-dir>"
+    exit
+fi
+
+# Assign the program arguments to bash variables.
+USER=$1
+GOOGLE_CLOUD_CREDENTIALS_PATH=$2
+CONFIGURATION_MODULE=$3
+DATA_DIR=$4
+
+# Build an image for this pipeline stage.
+docker build -t "$IMAGE_NAME" .
+
+# Create a container from the image that was just built.
+CMD="pipenv run python -u sync_csvs_to_engagement_db.py ${DRY_RUN} ${INCREMENTAL_ARG} \
+    ${USER} /credentials/google-cloud-credentials.json ${CONFIGURATION_MODULE}"
+
+if [[ "$INCREMENTAL_ARG" ]]; then
+    container="$(docker container create -w /app --mount source="$INCREMENTAL_CACHE_VOLUME_NAME",target=/cache "$IMAGE_NAME" /bin/bash -c "$CMD")"
+else
+    container="$(docker container create -w /app "$IMAGE_NAME" /bin/bash -c "$CMD")"
+fi
+
+echo "Created container $container"
+container_short_id=${container:0:7}
+
+# Copy input data into the container
+echo "Copying $GOOGLE_CLOUD_CREDENTIALS_PATH -> $container_short_id:/credentials/google-cloud-credentials.json"
+docker cp "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$container:/credentials/google-cloud-credentials.json"
+
+# Run the container
+echo "Starting container $container_short_id"
+docker start -a -i "$container"
+
+# Copy cache data out of the container for backup
+if [[ "$INCREMENTAL_ARG" ]]; then
+    echo "Copying $container_short_id:/cache/. -> $DATA_DIR/Cache"
+    mkdir -p "$DATA_DIR/Cache"
+    docker cp "$container:/cache/." "$DATA_DIR/Cache"
+fi
+
+# Tear down the container when it has run successfully
+docker container rm "$container" >/dev/null

--- a/src/common/cache.py
+++ b/src/common/cache.py
@@ -20,6 +20,19 @@ class Cache:
         """
         self.cache_dir = cache_dir
 
+    def set_string(self, entry_name, string):
+        export_path = f"{self.cache_dir}/{entry_name}.txt"
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
+            f.write(string)
+
+    def get_string(self, entry_name):
+        try:
+            with open(f"{self.cache_dir}/{entry_name}.txt") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
     def set_date_time(self, entry_name, date_time):
         export_path = f"{self.cache_dir}/{entry_name}.txt"
         IOUtils.ensure_dirs_exist_for_file(export_path)

--- a/src/csv_to_engagement_db/configuration.py
+++ b/src/csv_to_engagement_db/configuration.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+import pytz
+
+
+_MIN_DATE_UTC = pytz.timezone("utc").localize(datetime.min)
+_MAX_DATE_UTC = pytz.timezone("utc").localize(datetime.max)
+
+
+class CSVDatasetConfiguration:
+    def __init__(self, engagement_db_dataset, start_date=_MIN_DATE_UTC, end_date=_MAX_DATE_UTC):
+        """
+        Configuration for an engagement db dataset to sync csv messages to.
+
+        To restrict messages to this dataset by message timestamps, optionally set the `start_date`/`end_date`
+        properties.
+
+        :param engagement_db_dataset: Name of the dataset to use in the engagement database.
+        :type engagement_db_dataset: str
+        :param start_date: Start date for this dataset configuration.
+        :type start_date: datetime.datetime
+        :param end_date: End date for this dataset configuration.
+        :type end_date: datetime.datetime
+        """
+        self.engagement_db_dataset = engagement_db_dataset
+        self.start_date = start_date
+        self.end_date = end_date
+
+    def to_dict(self):
+        return {
+            "engagement_db_dataset": self.engagement_db_dataset,
+            "start_date": self.start_date,
+            "end_date": self.end_date
+        }
+
+
+class CSVSource:
+    def __init__(self, gs_url, engagement_db_datasets, timezone):
+        """
+        Configuration for a CSV data source. The CSV should have the headings 'Sender', 'Message', and 'ReceivedOn'.
+
+        :param gs_url: Google Cloud Storage URL to the csv file.
+        :type gs_url: str
+        :param engagement_db_datasets: Configuration for the engagement db datasets for this csv.
+        :type engagement_db_datasets: list of CSVDatasetConfiguration
+        :param timezone: Timezone to interpret the csv's timestamps in e.g. 'Africa/Nairobi'.
+        :type timezone: str
+        """
+        self.gs_url = gs_url
+        self.engagement_db_datasets = engagement_db_datasets
+        self.timezone = timezone
+
+    def get_dataset_for_timestamp(self, timestamp):
+        """
+        Gets the engagement db dataset for a message with the given timestamp, by searching the `engagement_db_datasets`
+        configurations for one which covers this time range.
+
+        Raises a LookupError if no matching dataset was found for this timestamp.
+        Raises an AssertionError if the timestamp matches multiple time ranges.
+
+        :param timestamp: Timestamp to get the engagement db dataset for.
+        :type timestamp: datetime.datetime
+        :return: Engagement db dataset for this timestamp.
+        :rtype: str
+        """
+        matching_dataset = None
+        for dataset in self.engagement_db_datasets:
+            if dataset.start_date <= timestamp < dataset.end_date:
+                assert matching_dataset is None, f"Timestamp {timestamp} matches multiple dataset time ranges"
+                matching_dataset = dataset.engagement_db_dataset
+
+        if matching_dataset is not None:
+            return matching_dataset
+
+        # No matching time range was found.
+        raise LookupError(timestamp)
+
+    def to_dict(self):
+        if self.engagement_db_datasets is None:
+            serialized_engagement_db_datasets = None
+        else:
+            serialized_engagement_db_datasets = [dataset.to_dict() for dataset in self.engagement_db_datasets]
+
+        return {
+            "gs_url": self.gs_url,
+            "engagement_db_datasets": serialized_engagement_db_datasets,
+            "timezone": self.timezone
+        }

--- a/src/csv_to_engagement_db/csv_to_engagement_db.py
+++ b/src/csv_to_engagement_db/csv_to_engagement_db.py
@@ -1,0 +1,255 @@
+import csv
+import urllib.parse
+from datetime import datetime
+from io import StringIO
+
+import pytz
+from core_data_modules.cleaners import URNCleaner
+from core_data_modules.logging import Logger
+from core_data_modules.util import SHAUtils
+from engagement_database.data_models import (Message, MessageDirections, MessageOrigin, MessageStatuses,
+                                             HistoryEntryOrigin)
+from storage.google_cloud import google_cloud_utils
+
+from src.common.cache import Cache
+from src.csv_to_engagement_db.sync_stats import CSVSyncEvents, CSVToEngagementDBSyncStats
+
+log = Logger(__name__)
+
+
+def _parse_date_string(date_string, timezone):
+    """
+    :param date_string: Date string to parse.
+    :type date_string: str
+    :param timezone: Timezone to interpret the date_string in, e.g. 'Africa/Nairobi'.
+    :type timezone: str
+    :return: Parsed datetime, in the given timezone.
+    :rtype: datetime.datetime
+    """
+    # Try parsing using a list of all the variants we've seen for expressing timestamps.
+    for date_format in ["%d/%m/%Y %H:%M", "%d/%m/%Y %H:%M:%S", "%Y/%m/%d %H:%M:%S.%f", "%Y/%m/%d %H:%M:%S"]:
+        try:
+            parsed_raw_date = datetime.strptime(date_string, date_format)
+            break
+        except ValueError:
+            pass
+    else:
+        raise ValueError(f"Could not parse date {date_string}")
+    return pytz.timezone(timezone).localize(parsed_raw_date)
+
+
+def _csv_message_to_engagement_db_message(csv_message, uuid_table, origin_id, csv_source):
+    """
+    Converts a CSV message to an engagement database message.
+
+    If there is no valid dataset for this converted message, returns None.
+
+    :param csv_message: Dictionary containing the headers: 'Sender', 'Message', and 'ReceivedOn'.
+    :type csv_message: dict
+    :param uuid_table: UUID table to use to re-identify the URNs so we can set the channel operator.
+    :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
+    :param origin_id: Origin id, for the message origin field.
+    :type origin_id: str
+    :param csv_source:
+    :type csv_source: src.csv_to_engagement_db.configuration.CSVSource
+    :return: `csv_message` as an engagement db message.
+    :rtype: engagement_database.data_models.Message | None
+    """
+    participant_uuid = csv_message["Sender"]
+    assert participant_uuid.startswith(uuid_table._uuid_prefix), f"Sender uuid does not start with uuid prefix " \
+                                                                 f"'{uuid_table._uuid_prefix}'"
+    participant_urn = uuid_table.uuid_to_data(participant_uuid)
+    channel_operator = URNCleaner.clean_operator(participant_urn)
+
+    timestamp = _parse_date_string(csv_message["ReceivedOn"], csv_source.timezone)
+
+    try:
+        dataset = csv_source.get_dataset_for_timestamp(timestamp)
+    except LookupError:
+        return None
+
+    return Message(
+        participant_uuid=participant_uuid,
+        text=csv_message["Message"],
+        timestamp=timestamp,
+        direction=MessageDirections.IN,
+        channel_operator=channel_operator,
+        status=MessageStatuses.LIVE,
+        dataset=dataset,
+        labels=[],
+        origin=MessageOrigin(
+            origin_id=origin_id,
+            origin_type="csv"
+        )
+    )
+
+
+def _engagement_db_has_message(engagement_db, message):
+    """
+    Checks if an engagement database contains a message with the same origin id as the given message.
+
+    :param engagement_db: Engagement database to check for the message.
+    :type engagement_db: engagement_database.EngagementDatabase
+    :param message: Message to check for existence.
+    :type message: engagement_database.data_models.Message
+    :return: Whether a message with this text, timestamp, and participant_uuid exists in the engagement database.
+    :rtype: bool
+    """
+    matching_messages_filter = lambda q: q.where("origin.origin_id", "==", message.origin.origin_id)
+    matching_messages = engagement_db.get_messages(firestore_query_filter=matching_messages_filter)
+    assert len(matching_messages) < 2
+
+    return len(matching_messages) > 0
+
+
+def _ensure_engagement_db_has_message(engagement_db, message, message_origin_details, dry_run=False):
+    """
+    Ensures that the given message exists in an engagement database.
+
+    This function will only write to the database if a message with the same origin_id doesn't already exist in the
+    database.
+
+    :param engagement_db: Engagement database to use.
+    :type engagement_db: engagement_database.EngagementDatabase
+    :param message: Message to make sure exists in the engagement database.
+    :type message: engagement_database.data_models.Message
+    :param message_origin_details: Message origin details, to be logged in the HistoryEntryOrigin.details.
+    :type message_origin_details: dict
+    :param dry_run: Whether to perform a dry run.
+    :type dry_run: bool
+    :return sync_events: Sync event.
+    :rtype str
+    """
+    if _engagement_db_has_message(engagement_db, message):
+        log.debug(f"Message already in engagement database")
+        return CSVSyncEvents.MESSAGE_ALREADY_IN_ENGAGEMENT_DB
+
+    log.debug(f"Adding message to engagement database dataset {message.dataset}...")
+    if not dry_run:
+        engagement_db.set_message(
+            message,
+            HistoryEntryOrigin(origin_name="CSV -> Database Sync", details=message_origin_details)
+        )
+    return CSVSyncEvents.ADD_MESSAGE_TO_ENGAGEMENT_DB
+
+
+def _sync_csv_to_engagement_db(google_cloud_credentials_file_path, csv_source, engagement_db, uuid_table, cache=None,
+                               dry_run=False):
+    """
+    Syncs a CSV to an engagement database.
+
+    :param google_cloud_credentials_file_path: Path to the Google Cloud service account credentials file to use when
+                                               downloading the CSV.
+    :type google_cloud_credentials_file_path: str
+    :param csv_source: CSV source to sync.
+    :type csv_source: src.csv_to_engagement_db.configuration.CSVSource
+    :param engagement_db: Engagement database to sync the CSV to.
+    :type engagement_db: engagement_database.EngagementDatabase
+    :param uuid_table: UUID table to use to re-identify the URNs so we can set the channel operator.
+    :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
+    :param cache:
+    :type cache: src.common.cache.Cache
+    :param dry_run: Whether to perform a dry run.
+    :type dry_run: bool
+    :return: Sync stats for the sync.
+    :rtype: CSVToEngagementDBSyncStats
+    """
+    sync_stats = CSVToEngagementDBSyncStats()
+
+    log.info(f"Downloading csv from '{csv_source.gs_url}'...")
+    raw_csv_string = google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path, csv_source.gs_url)
+    csv_hash = SHAUtils.sha_string(raw_csv_string)
+    raw_data = list(csv.DictReader(StringIO(raw_csv_string)))
+    log.info(f"Downloaded {len(raw_data)} messages in csv '{csv_source.gs_url}'")
+
+    # Convert the gs_url to a format that is safe to use as a cache entry name.
+    escaped_csv_url = urllib.parse.quote_plus(csv_source.gs_url)
+    if cache is None:
+        prev_csv_hash = None
+    else:
+        prev_csv_hash = cache.get_string(escaped_csv_url)
+
+    if prev_csv_hash is not None:
+        assert csv_hash == prev_csv_hash, f"CSV '{csv_source.gs_url}' differs since the last time it was requested. " \
+                                          f"To avoid accidental duplication, please inspect the problem, then clear " \
+                                          f"the cache and re-run when it is safe to proceed."
+        log.info("This file matches a previous version of the file that was processed in the past.")
+        log.info("Returning without reprocessing any of the messages in this file.")
+        return sync_stats
+
+    for i, csv_msg in enumerate(raw_data):
+        log.info(f"Processing message {i + 1}/{len(raw_data)}...")
+        sync_stats.add_event(CSVSyncEvents.READ_ROW_FROM_CSV)
+        engagement_db_message = _csv_message_to_engagement_db_message(
+            csv_msg, uuid_table, f"csv_{csv_hash}.row_{i}", csv_source
+        )
+
+        if engagement_db_message is None:
+            log.info(f"No matching dataset for this message, sent at time '{csv_msg['ReceivedOn']}'")
+            sync_stats.add_event(CSVSyncEvents.MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP)
+            continue
+
+        message_origin_details = {
+            "csv_row_number": i,
+            "csv_row_data": csv_msg,
+            "csv_sync_configuration": csv_source.to_dict(),
+            "csv_hash": csv_hash
+        }
+        sync_event = _ensure_engagement_db_has_message(engagement_db, engagement_db_message, message_origin_details, dry_run)
+        sync_stats.add_event(sync_event)
+
+    if cache is not None and not dry_run:
+        cache.set_string(escaped_csv_url, csv_hash)
+
+    return sync_stats
+
+
+def sync_csvs_to_engagement_db(google_cloud_credentials_file_path, csv_sources, engagement_db, uuid_table,
+                               cache_path=None, dry_run=False):
+    """
+    Syncs CSVs to an engagement database.
+
+    The CSVs must contain the headers 'Sender', 'Message', and 'ReceivedOn'.
+
+    Messages are synced using the file hash and row index in the CSV as the message origin_ids. This means a CSV
+    can't be edited after it has been synced without first removing the messages from the original sync.
+
+    :param google_cloud_credentials_file_path: Path to the Google Cloud service account credentials file to use when
+                                               downloading the CSVs.
+    :type google_cloud_credentials_file_path: str
+    :param csv_sources: CSV sources to sync to the engagement database.
+    :type csv_sources: list of src.csv_to_engagement_db.configuration.CSVSource
+    :param engagement_db: Engagement database to sync the CSVs to.
+    :type engagement_db: engagement_database.EngagementDatabase
+    :param uuid_table: UUID table to use to re-identify the URNs so we can set the channel operator.
+    :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
+    :param cache_path: Path to a directory to use to cache results needed for incremental operation.
+                       If None, runs in non-incremental mode.
+    :type cache_path: str | None
+    :param dry_run: Whether to perform a dry run.
+    :type dry_run: bool
+    """
+    if cache_path is None:
+        cache = None
+    else:
+        cache = Cache(cache_path)
+
+    source_to_sync_stats = dict()
+    for i, csv_source in enumerate(csv_sources):
+        log.info(f"Syncing csv {i + 1}/{len(csv_sources)}: {csv_source.gs_url}...")
+        source_sync_stats = _sync_csv_to_engagement_db(
+            google_cloud_credentials_file_path, csv_source, engagement_db, uuid_table, cache, dry_run
+        )
+        source_to_sync_stats[csv_source.gs_url] = source_sync_stats
+
+    # Log the summaries of actions taken for each dataset then for all datasets combined.
+    all_sync_stats = CSVToEngagementDBSyncStats()
+    for csv_source in csv_sources:
+        log.info(f"Summary of actions for csv source '{csv_source.gs_url}':")
+        source_to_sync_stats[csv_source.gs_url].print_summary()
+        all_sync_stats.add_stats(source_to_sync_stats[csv_source.gs_url])
+
+    dry_run_text = " (dry run)" if dry_run else ""
+    log.info(f"Summary of actions for all {len(csv_sources)} csv source(s){dry_run_text}:")
+    all_sync_stats.print_summary()

--- a/src/csv_to_engagement_db/sync_stats.py
+++ b/src/csv_to_engagement_db/sync_stats.py
@@ -1,0 +1,28 @@
+from core_data_modules.logging import Logger
+
+from src.common.sync_stats import SyncStats
+
+log = Logger(__name__)
+
+
+class CSVSyncEvents:
+    READ_ROW_FROM_CSV = "read_row_from_csv"
+    MESSAGE_ALREADY_IN_ENGAGEMENT_DB = "message_already_in_engagement_db"
+    ADD_MESSAGE_TO_ENGAGEMENT_DB = "add_message_to_engagement_db"
+    MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP = "message_skipped_no_matching_timestamp"
+
+
+class CSVToEngagementDBSyncStats(SyncStats):
+    def __init__(self):
+        super().__init__({
+            CSVSyncEvents.READ_ROW_FROM_CSV: 0,
+            CSVSyncEvents.MESSAGE_ALREADY_IN_ENGAGEMENT_DB: 0,
+            CSVSyncEvents.ADD_MESSAGE_TO_ENGAGEMENT_DB: 0,
+            CSVSyncEvents.MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP: 0
+        })
+
+    def print_summary(self):
+        log.info(f"CSV rows read: {self.event_counts[CSVSyncEvents.READ_ROW_FROM_CSV]}")
+        log.info(f"Messages already in engagement db: {self.event_counts[CSVSyncEvents.MESSAGE_ALREADY_IN_ENGAGEMENT_DB]}")
+        log.info(f"Messages added to engagement db: {self.event_counts[CSVSyncEvents.ADD_MESSAGE_TO_ENGAGEMENT_DB]}")
+        log.info(f"Messages skipped because they didn't match a dataset time-range: {self.event_counts[CSVSyncEvents.MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP]}")

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -1,14 +1,15 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Optional, List
 
 from core_data_modules.data_models import CodeScheme
-from core_data_modules.cleaners import somali, Codes
 from core_data_modules.analysis.traffic_analysis import TrafficLabel
 
 from src.common.configuration import (RapidProClientConfiguration, CodaClientConfiguration, UUIDTableClientConfiguration,
                                       EngagementDatabaseClientConfiguration, OperationsDashboardConfiguration,
                                       ArchiveConfiguration)
+from src.csv_to_engagement_db.configuration import (CSVSource, CSVDatasetConfiguration)
 
 from src.engagement_db_coda_sync.configuration import (CodaSyncConfiguration, CodaDatasetConfiguration,
                                                        CodeSchemeConfiguration)
@@ -20,7 +21,6 @@ from src.engagement_db_to_analysis.configuration import (AnalysisDatasetConfigur
                                                          DatasetTypes, AgeCategoryConfiguration, AnalysisLocations,
                                                          CodingConfiguration, GoogleDriveUploadConfiguration,
                                                          MembershipGroupConfiguration, AnalysisConfiguration)
-
 
 def load_code_scheme(fname):
     with open(f"code_schemes/{fname}.json") as f:
@@ -58,6 +58,7 @@ class PipelineConfiguration:
     test_participant_uuids: [] = None
     description: str = None
     rapid_pro_sources: [RapidProSource] = None
+    csv_sources: Optional[List[CSVSource]] = None
     coda_sync: CodaConfiguration = None
     rapid_pro_target: RapidProTarget = None
     analysis: AnalysisConfiguration = None

--- a/sync_csvs_to_engagement_db.py
+++ b/sync_csvs_to_engagement_db.py
@@ -1,0 +1,55 @@
+import argparse
+import importlib
+import subprocess
+
+from core_data_modules.logging import Logger
+from engagement_database.data_models import HistoryEntryOrigin
+
+from src.csv_to_engagement_db.csv_to_engagement_db import sync_csvs_to_engagement_db
+
+log = Logger(__name__)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Syncs data from CSVs in Google Cloud Storage to an "
+                                                 "engagement database")
+
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Logs the updates that would be made without updating anything.")
+    parser.add_argument("--incremental-cache-path",
+                        help="Path to a directory to use to cache results needed for incremental operation.")
+    parser.add_argument("user", help="Identifier of the user launching this program")
+    parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
+                        help="Path to a Google Cloud service account credentials file to use to access the "
+                             "credentials bucket")
+    parser.add_argument("configuration_module",
+                        help="Configuration module to import e.g. 'configurations.test_config'. "
+                             "This module must contain a PIPELINE_CONFIGURATION property")
+
+    args = parser.parse_args()
+
+    dry_run = args.dry_run
+    incremental_cache_path = args.incremental_cache_path
+    user = args.user
+    google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
+    pipeline_config = importlib.import_module(args.configuration_module).PIPELINE_CONFIGURATION
+
+    pipeline = pipeline_config.pipeline_name
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+    project = subprocess.check_output(["git", "config", "--get", "remote.origin.url"]).decode().strip()
+
+    HistoryEntryOrigin.set_defaults(user, project, pipeline, commit)
+
+    if pipeline_config.csv_sources is None or len(pipeline_config.csv_sources) == 0:
+        log.info(f"No CSV sources specified; exiting")
+        exit(0)
+
+    dry_run_text = "(dry run)" if dry_run else ""
+    log.info(f"Synchronizing data from CSVs to an engagement database {dry_run_text}")
+
+    engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
+    uuid_table = pipeline_config.uuid_table.init_uuid_table_client(google_cloud_credentials_file_path)
+
+    sync_csvs_to_engagement_db(
+        google_cloud_credentials_file_path, pipeline_config.csv_sources, engagement_db, uuid_table,
+        incremental_cache_path, dry_run
+    )


### PR DESCRIPTION
This adds ~11k messages, of which ~2k are demogs. Full dataset breakdown here: https://docs.google.com/spreadsheets/d/1M-8rUkm-U539p3aIRZ81TyDgpnBVDho_qNARClFulkA/edit?usp=sharing. Will add the configurations for the remaining csvs once this is reviewed.

Note this needs the changes being worked on in #9 to be merged before this can be run.

Code scheme files are copied unmodified from SSF-Elections.
Source code changes are copied unmodified from the Test-Pipeline-Engagement-DB repo.
The only file with changes that need careful review is the create_imaqal_pool configuration file.