### PR TITLE
Don't update the code user/code scheme configuration for previous rqa datasets

### DIFF
--- a/configurations/create_imaqal_database.py
+++ b/configurations/create_imaqal_database.py
@@ -19,7 +19,8 @@ def make_rqa_coda_dataset_configs(dataset_name_prefix, coda_dataset_id_prefix, c
                         code_scheme=load_code_scheme(f"{code_scheme_prefix}{i}"),
                         auto_coder=None)
                 ],
-                ws_code_match_value=f"{dataset_name_prefix}{i}"
+                ws_code_match_value=f"{dataset_name_prefix}{i}",
+                update_users_and_code_schemes=False
             )
         )
     return dataset_configs

--- a/src/engagement_db_coda_sync/configuration.py
+++ b/src/engagement_db_coda_sync/configuration.py
@@ -18,6 +18,7 @@ class CodaDatasetConfiguration:
     code_scheme_configurations: [CodeSchemeConfiguration]
     ws_code_match_value: str
     dataset_users_file_url: Optional[str] = None
+    update_users_and_code_schemes: bool = True
 
 
 @dataclass

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -45,6 +45,11 @@ def ensure_coda_datasets_up_to_date(coda, coda_config, google_cloud_credentials_
 
     ws_correct_dataset_code_scheme = coda_config.ws_correct_dataset_code_scheme
     for dataset_config in coda_config.dataset_configurations:
+        if not dataset_config.update_users_and_code_schemes:
+            log.debug(f"Not updating the user ids or code schemes in coda dataset {dataset_config.coda_dataset_id} "
+                      f"because `update_users_and_code_schemes` is {dataset_config.update_users_and_code_schemes}")
+            continue
+
         log.info(f"Updating user ids and code schemes in coda dataset '{dataset_config.coda_dataset_id}'")
         config_user_ids = []
         if dataset_config.dataset_users_file_url:


### PR DESCRIPTION
This is so we don't override the configs tailored to those projects with the ones for RVI