### PR TITLE
Golis recovery csv, covering 03/27 to 03/28

### DIFF
--- a/configurations/pipeline_configuration.py
+++ b/configurations/pipeline_configuration.py
@@ -43,6 +43,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
         )
     ],
     csv_sources=[
+        # Hormud
         CSVSource(
             "gs://avf-project-datasets/2022/RVI-ELECTIONS/recovered_hormuud_2022_03_12_to_2022_03_18_de_identified.csv",
             engagement_db_datasets=[
@@ -60,6 +61,17 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 CSVDatasetConfiguration("rvi_elections_s01e02",
                                         start_date=isoparse("2022-03-19T00:00:00+03:00"),
                                         end_date=isoparse("2022-03-26T00:00:00+03:00"))
+            ],
+            timezone="Africa/Mogadishu"
+        ),
+        # Golis
+        CSVSource(
+            "gs://avf-project-datasets/2022/RVI-ELECTIONS/recovered_golis_2022_03_27_to_2022_03_28_de_identified.csv",
+            engagement_db_datasets=[
+                # This contains data from 27th March, until 28th March.
+                CSVDatasetConfiguration("rvi_elections_s01e03",
+                                        start_date=isoparse("2022-03-27T00:00:00+03:00"),
+                                        end_date=isoparse("2022-03-29T00:00:00+03:00"))
             ],
             timezone="Africa/Mogadishu"
         )


### PR DESCRIPTION
I have updated L35 of script  preprocess_recovered_hormuud_messages to get Golis messages by checking if the msg urn startswith 25290 and Log messages. 

[Logs](https://drive.google.com/file/d/1gpWLp7ojo8mYMcRyhYBGfAVDxnLnAToL/view?usp=sharing)