### PR TITLE
Update the engagement-data-pipeline dependency to v3.0.0

### DIFF
--- a/configurations/docker_image_name.txt
+++ b/configurations/docker_image_name.txt
@@ -1,1 +1,1 @@
-ghcr.io/africasvoices/engagement-data-pipeline:v2.0.0
+ghcr.io/africasvoices/engagement-data-pipeline:v3.0.0


### PR DESCRIPTION
(The breaking change for this release was in Google Forms, which this pipeline doesn't use)