### PR TITLE
Work around SDC crashing due to unknown operator 'NC'

### DIFF
--- a/code_schemes/demographics/imaqal_operator.json
+++ b/code_schemes/demographics/imaqal_operator.json
@@ -107,7 +107,10 @@
       "DisplayText": "NC (not coded)",
       "NumericValue": -30,
       "StringValue": "NC",
-      "VisibleInCoda": true
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "NC"
+      ]
     },
     {
       "CodeID": "code-STOP-08b832a8",


### PR DESCRIPTION
This NC is coming from a new operator with prefix +25277. Treating it as NC here allows us to keep running the pipeline while we understand which operator +25277 originates from.